### PR TITLE
Add local tap battle structure

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'screens/home_screen.dart';
+import 'services/local_storage_service.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Hive.initFlutter();
+  await LocalStorageService().init();
+  runApp(const ThumbsOutApp());
+}
+
+class ThumbsOutApp extends StatelessWidget {
+  const ThumbsOutApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Thumbs Out',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const HomeScreen(),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+import 'match_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.grey[300],
+      body: Center(
+        child: ElevatedButton(
+          child: const Text('Start'),
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const MatchScreen()),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/match_screen.dart
+++ b/lib/screens/match_screen.dart
@@ -1,0 +1,161 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../widgets/countdown_overlay.dart';
+import '../widgets/tap_flash_overlay.dart';
+import '../services/local_storage_service.dart';
+import 'result_screen.dart';
+
+class MatchScreen extends StatefulWidget {
+  const MatchScreen({super.key});
+
+  @override
+  State<MatchScreen> createState() => _MatchScreenState();
+}
+
+class _MatchScreenState extends State<MatchScreen> {
+  int blueCount = 0;
+  int redCount = 0;
+  bool blueFlash = false;
+  bool redFlash = false;
+  bool matchActive = false;
+  String? countdownText = '3';
+  Timer? _countdownTimer;
+  Timer? _matchTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _startCountdown();
+  }
+
+  void _startCountdown() {
+    int count = 3;
+    _countdownTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (count > 1) {
+        setState(() {
+          count--;
+          countdownText = '$count';
+        });
+      } else {
+        timer.cancel();
+        setState(() {
+          countdownText = 'FIGHT';
+        });
+        Future.delayed(const Duration(milliseconds: 700), () {
+          setState(() {
+            countdownText = null;
+            matchActive = true;
+          });
+          _startMatch();
+        });
+      }
+    });
+  }
+
+  void _startMatch() {
+    _matchTimer = Timer(const Duration(seconds: 10), _endMatch);
+  }
+
+  void _endMatch() {
+    setState(() {
+      matchActive = false;
+    });
+    final best = LocalStorageService().updateBest(blueCount, redCount);
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (_) => ResultScreen(
+          blueCount: blueCount,
+          redCount: redCount,
+          best: best,
+        ),
+      ),
+    );
+  }
+
+  void _tapBlue() {
+    if (!matchActive) return;
+    setState(() {
+      blueCount++;
+      blueFlash = true;
+    });
+    Future.delayed(const Duration(milliseconds: 300), () {
+      if (mounted) {
+        setState(() => blueFlash = false);
+      }
+    });
+  }
+
+  void _tapRed() {
+    if (!matchActive) return;
+    setState(() {
+      redCount++;
+      redFlash = true;
+    });
+    Future.delayed(const Duration(milliseconds: 300), () {
+      if (mounted) {
+        setState(() => redFlash = false);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _countdownTimer?.cancel();
+    _matchTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          Column(
+            children: [
+              Expanded(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: _tapBlue,
+                  child: Container(
+                    color: Colors.blue[100],
+                  ),
+                ),
+              ),
+              Expanded(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: _tapRed,
+                  child: Container(
+                    color: Colors.red[100],
+                  ),
+                ),
+              ),
+            ],
+          ),
+          Column(
+            children: [
+              Expanded(
+                child: TapFlashOverlay(
+                  active: blueFlash,
+                  color: Colors.blueAccent,
+                  alignment: Alignment.topCenter,
+                ),
+              ),
+              Expanded(
+                child: TapFlashOverlay(
+                  active: redFlash,
+                  color: Colors.redAccent,
+                  alignment: Alignment.bottomCenter,
+                ),
+              ),
+            ],
+          ),
+          if (countdownText != null)
+            CountdownOverlay(text: countdownText!),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class ResultScreen extends StatelessWidget {
+  final int blueCount;
+  final int redCount;
+  final int best;
+
+  const ResultScreen({
+    super.key,
+    required this.blueCount,
+    required this.redCount,
+    required this.best,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final winner = blueCount == redCount
+        ? 'DRAW'
+        : blueCount > redCount
+            ? 'BLUE WINS!'
+            : 'RED WINS!';
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              winner,
+              style: const TextStyle(
+                fontSize: 32,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 20),
+            Text('Blue: $blueCount'),
+            Text('Red: $redCount'),
+            const SizedBox(height: 20),
+            Text('Best: $best'),
+            const SizedBox(height: 40),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).popUntil((route) => route.isFirst);
+              },
+              child: const Text('Play Again'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/local_storage_service.dart
+++ b/lib/services/local_storage_service.dart
@@ -1,0 +1,27 @@
+import 'package:hive/hive.dart';
+
+class LocalStorageService {
+  static final LocalStorageService _instance = LocalStorageService._internal();
+  factory LocalStorageService() => _instance;
+  LocalStorageService._internal();
+
+  static const String _boxName = 'thumbs_out';
+  static const String _bestKey = 'best_score';
+  late Box<int> _box;
+
+  Future<void> init() async {
+    _box = await Hive.openBox<int>(_boxName);
+  }
+
+  int updateBest(int blue, int red) {
+    final winner = blue > red ? blue : red;
+    final current = _box.get(_bestKey, defaultValue: 0) ?? 0;
+    if (winner > current) {
+      _box.put(_bestKey, winner);
+      return winner;
+    }
+    return current;
+  }
+
+  int getBest() => _box.get(_bestKey, defaultValue: 0) ?? 0;
+}

--- a/lib/services/match_logic.dart
+++ b/lib/services/match_logic.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/foundation.dart';
+
+class MatchLogic extends ChangeNotifier {
+  int blueCount = 0;
+  int redCount = 0;
+  bool active = false;
+
+  void start() {
+    blueCount = 0;
+    redCount = 0;
+    active = true;
+    notifyListeners();
+  }
+
+  void stop() {
+    active = false;
+    notifyListeners();
+  }
+
+  void tapBlue() {
+    if (!active) return;
+    blueCount++;
+    notifyListeners();
+  }
+
+  void tapRed() {
+    if (!active) return;
+    redCount++;
+    notifyListeners();
+  }
+}

--- a/lib/widgets/countdown_overlay.dart
+++ b/lib/widgets/countdown_overlay.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class CountdownOverlay extends StatelessWidget {
+  final String text;
+  const CountdownOverlay({super.key, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Container(
+        color: Colors.black54,
+        alignment: Alignment.center,
+        child: Text(
+          text,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 64,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/tap_flash_overlay.dart
+++ b/lib/widgets/tap_flash_overlay.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class TapFlashOverlay extends StatelessWidget {
+  final bool active;
+  final Color color;
+  final Alignment alignment;
+
+  const TapFlashOverlay({
+    super.key,
+    required this.active,
+    required this.color,
+    required this.alignment,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: AnimatedOpacity(
+        opacity: active ? 1 : 0,
+        duration: const Duration(milliseconds: 300),
+        child: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: alignment,
+              end: Alignment.center,
+              colors: [
+                color.withOpacity(0.6),
+                color.withOpacity(0.0),
+              ],
+              stops: const [0.0, 0.15],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,23 @@
+name: thumbs_out
+version: 0.1.0
+publish_to: 'none'
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flame: ^1.8.1
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/images/


### PR DESCRIPTION
## Summary
- add Flutter app scaffolding for local 1v1 tap battle
- implement match screen with countdown, glow effects, and tap tracking
- store personal best locally via Hive

## Testing
- `dart format lib pubspec.yaml` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: package not found)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ec24476608331b4b1625909a29240