### PR TITLE
Fix background asset path and add fallback image handling

### DIFF
--- a/lib/screens/match_screen.dart
+++ b/lib/screens/match_screen.dart
@@ -114,8 +114,10 @@ class _MatchScreenState extends State<MatchScreen> {
         children: [
           Positioned.fill(
             child: Image.asset(
-              'assets/images/dojo_mat_topdown.png',
+              'assets/images/pvpbackground.png',
               fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) =>
+                  Container(color: Colors.grey),
             ),
           ),
           Column(
@@ -178,8 +180,7 @@ class _MatchScreenState extends State<MatchScreen> {
               ),
             ],
           ),
-          if (countdownText != null)
-            CountdownOverlay(text: countdownText!),
+          if (countdownText != null) CountdownOverlay(text: countdownText!),
         ],
       ),
     );

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,12 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:thumbs_out/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('Home screen shows Start button', (WidgetTester tester) async {
+    await tester.pumpWidget(const ThumbsOutApp());
+    expect(find.text('Start'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- load correct background asset in match screen with fallback container when the image fails
- update widget test to pump `ThumbsOutApp`

## Testing
- `flutter clean`
- `flutter pub get`
- `flutter run -d linux --no-resident` *(fails: Could not find compiler set in environment variable CXX: clang++)*
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_688fb1c139e08331a41636e5a5168358